### PR TITLE
Increase size of `appOpenURI`

### DIFF
--- a/Administration/CreatePowerAppTable.sql
+++ b/Administration/CreatePowerAppTable.sql
@@ -17,7 +17,7 @@ CREATE TABLE [dbo].[PowerApp](
 	[description] [nvarchar](max) NULL,
 	[sharedUsersCount] [int] NULL,
 	[sharedGroupsCount] [int] NULL,
-	[appOpenURI] [nvarchar](80) NULL,
+	[appOpenURI] [nvarchar](120) NULL,
 	[isFeaturedApp] [bit] NULL,
 	[bypassConsent] [bit] NULL,
 	[isSharePointForm] [bit] NULL,


### PR DESCRIPTION
My appOpenURI was 114 characters long. Failed on 80. Bumped up to 120, Flow successful.