### PR TITLE
Add issue template chooser in place of the pinned issue - Format correction

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: [CoE Starter Kit] Issues
+  - name: CoE Starter Kit - Issues
     url: https://github.com/microsoft/coe-starter-kit/issues
     about: Please file issues related to the CoE Starter Kit in the microsoft/coe-starter-kit repository.


### PR DESCRIPTION
Hey team,

It seems it is not possible to have "[]" characters for the value of the "name" of a contact link in the GitHub template chooser.

The template chooser should work correctly now.

Have a great day 😊